### PR TITLE
Prepare for QCheckBox stateChanged -> checkStateChanged

### DIFF
--- a/cut_list/cut_list_ui.py
+++ b/cut_list/cut_list_ui.py
@@ -26,7 +26,11 @@ class cutListUI:
         self.form.cut_width.setProperty("minimum", 0.0)
 
         # Set Default Options
-        self.form.use_nesting.stateChanged.connect(self.useNestingToggle)
+        if hasattr(self.form.use_nesting, "checkStateChanged"):
+            self.form.use_nesting.checkStateChanged.connect(self.useNestingToggle)
+        else:
+            self.form.use_nesting.stateChanged.connect(self.useNestingToggle)
+        self.form.use_nesting.setChecked(False)
 
         self.form.use_nesting.setChecked(False)
 


### PR DESCRIPTION
Due to Deprecation warnings already being raised in Qt6.9.0 and to maintain backwards compatibility to Qt5.x this PR allows all current supported builds to still function as expected.